### PR TITLE
Remove references to nonexistent TOML files.

### DIFF
--- a/zmq.gpr
+++ b/zmq.gpr
@@ -31,7 +31,7 @@
 ------------------------------------------------------------------------------
 with "libzmq.gpr";
 project ZMQ is
-   for Languages use ("Ada", "Makefile", "Python", "Toml");
+   for Languages use ("Ada", "Makefile", "Python");
 
    type ZMQ_Kind_Type is ("static", "relocatable");
    ZMQ_Kind : ZMQ_Kind_Type := external ("LIBRARY_TYPE", "static");
@@ -91,7 +91,6 @@ project ZMQ is
       for Specification_Exceptions ("Makefile") use ("Makefile");
       for Spec_Suffix ("sed") use ".sed";
       for Body_Suffix ("Python") use ".py";
-      for Body_Suffix ("Toml") use ".toml";
       for Implementation_Exceptions ("Python") use ("configure");
    end Naming;
 end ZMQ;


### PR DESCRIPTION
There are no TOML files in the project, but the `zmq.gpr` file mentioned them. `gprbuild` now issues a warning when this happens.

Fixes #18 