### PR TITLE
udate specfile with patch, so that examples are building

### DIFF
--- a/doc/0001-change-library-path.patch
+++ b/doc/0001-change-library-path.patch
@@ -1,0 +1,65 @@
+From e5197387d3c0a62f078d7200db6087c7f02cca57 Mon Sep 17 00:00:00 2001
+From: Lutz Berger <lutz.berger@airbus.com>
+Date: Thu, 13 Nov 2025 08:58:29 +0100
+Subject: [PATCH] change library path
+
+---
+ Makefile                       | 1 +
+ examples/zmq-examples.gpr.inst | 2 +-
+ zmq.gpr.inst                   | 7 ++++---
+ 3 files changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 7c75354..b4914dc 100644
+--- a/Makefile
++++ b/Makefile
+@@ -46,6 +46,7 @@ install: compile uninstall
+ 
+ 	cp -f src/zmq.ad* ${DESTDIR}/${PREFIX}/include/zmq
+ 	cp -f src/zmq-*.ad* ${DESTDIR}/${PREFIX}/include/zmq
++	cp -f src/gen/zmq-*.ad* ${DESTDIR}/${PREFIX}/include/zmq
+ 	chmod -w ${DESTDIR}/${PREFIX}/include/zmq/*.ad?
+ #	(cd ${DESTDIR}/${PREFIX}/lib; for i in `find -name lib*.so*`; do ln -s $$i ; done)s
+ 	cp zmq.gpr.inst ${DESTDIR}/${ADA_PROJECT_DIR}/zmq.gpr
+diff --git a/examples/zmq-examples.gpr.inst b/examples/zmq-examples.gpr.inst
+index 1c1c366..b702ab6 100644
+--- a/examples/zmq-examples.gpr.inst
++++ b/examples/zmq-examples.gpr.inst
+@@ -10,7 +10,7 @@ project ZMQ.Examples is
+    for Exec_Dir use ".";
+ 
+    package Compiler is
+-      for Default_Switches ("ada") use ("-g", "-O2", "-gnatf", "-gnat05");
++      for Default_Switches ("ada") use ("-g", "-O2", "-gnatf", "-gnat2012");
+    end Compiler;
+ 
+    package Binder is
+diff --git a/zmq.gpr.inst b/zmq.gpr.inst
+index 748cab2..581ba51 100644
+--- a/zmq.gpr.inst
++++ b/zmq.gpr.inst
+@@ -31,17 +31,18 @@
+ ------------------------------------------------------------------------------
+ with "libzmq.gpr";
+ project ZMQ is
+-   For Languages use ("Ada", "Makefile", "Python");
++   For Languages use ("Ada");
+ 
+    type ZMQ_Kind_Type is ("static", "relocatable");
+-   ZMQ_Kind : ZMQ_Kind_Type := external ("LIBRARY_TYPE", "static");
++   ZMQ_Kind : ZMQ_Kind_Type := external ("LIBRARY_TYPE", "relocatable");
+    Version := "4.0.1";
+ 
+    for Library_Name use "zmqAda";
+    for Library_Version use "lib" & project'Library_Name & ".so." & Version;
+-   for Library_Dir use "../zmq/" & ZMQ_Kind;
++   for Library_Dir use "../../lib/zmq/" & ZMQ_Kind;
+    for Source_Dirs use ("../../include/zmq");
+    for Externally_Built use "True";
++
+    case ZMQ_Kind is
+       when "static" =>
+          for Library_Kind use "static";
+-- 
+2.51.0
+

--- a/doc/fedora.spec
+++ b/doc/fedora.spec
@@ -9,7 +9,7 @@ License:	MIT
 URL:		zeromq.org
 Source:	%{name}-%{version}.tar.bz
 Patch0: 0001-change-library-path.patch
-BuildRequires:	gnatpro-devel zeromq-devel >= %{version}
+BuildRequires:	gcc-gnat zeromq-devel >= %{version}
 Requires:	zeromq-devel >= %{version}
 BuildArchitectures: x86_64
 
@@ -26,6 +26,7 @@ make %{?_smp_mflags}
 Summary:        Devel package for Ada binding for zeromq
 Group:          System Environment/Libraries
 License:        MIT
+Requires:       %name = %version
 
 %description devel
 Devel package for Ada binding for zeromq
@@ -96,5 +97,7 @@ rm -f %{buildroot}/usr/gnat/lib/zmq/static/libzmqAda.a
 %{_prefix}/gnat/share/zmq/examples/Ada/* 
 
 %changelog
+* Fri Nov 14 2025 Lutz Beger <lutz.berger@airbus.com> 4.1.5-1
+- update spec file and provide patch
 * Wed Feb 2 2011 Pavel Zhukov <pavel@zhukoff.net> - 2.0.10-1
 - Initial package

--- a/doc/fedora.spec
+++ b/doc/fedora.spec
@@ -1,31 +1,31 @@
 Name:		zeromq-ada
-Version:	3.2.0
+Version:	4.1.5
 Release:	1%{?dist}
 Summary:	Ada binding for zeromq
 
 Group:          System Environment/Libraries
 
-License:	GPLv2
+License:	MIT
 URL:		zeromq.org
-Source0:	%{name}-%{version}.tar.gz
-Patch0: 	%{name}-gnat.patch
-BuildRequires:	libgnat-static gcc-gnat zeromq >= %{version}
-Requires:	zeromq >= %{version}
+Source:	%{name}-%{version}.tar.bz
+Patch0: 0001-change-library-path.patch
+BuildRequires:	gnatpro-devel zeromq-devel >= %{version}
+Requires:	zeromq-devel >= %{version}
+BuildArchitectures: x86_64
 
 %description
 Ada bindings for zeromq
 
 %prep
-%setup -q -n zeromq-ada
+%setup -n zeromq-ada
 %patch0 -p1
-
 %build
 make %{?_smp_mflags}
 
 %package devel
 Summary:        Devel package for Ada binding for zeromq
 Group:          System Environment/Libraries
-License:        GPLv2
+License:        MIT
 
 %description devel
 Devel package for Ada binding for zeromq
@@ -34,49 +34,66 @@ Devel package for Ada binding for zeromq
 %install
 rm -rf %{buildroot}
 make install DESTDIR=%{buildroot}
-rm -f %{buildroot}/usr/lib/zmq/static/libzmqAda.a
+#correct whate makefile makes wrong
+%{__mkdir} -p %{buildroot}%{_prefix}/gnat/share/gpr
+%{__mv} %{buildroot}/zmq.gpr %{buildroot}%{_prefix}/gnat/share/gpr/
+%{__install} libzmq.gpr -m 644  %{buildroot}%{_prefix}/gnat/share/gpr/libzmq.gpr
+rm -f %{buildroot}/usr/gnat/lib/zmq/static/libzmqAda.a
 
 %files
 %defattr(-,root,root,-)
-%doc README
-/usr/lib/zmq/relocatable/libzmqAda.so.%{version}
+/usr/gnat/lib/zmq/relocatable/libzmqAda.so.%{version}
 
 
 %files devel
 %defattr(-,root,root,-)
-/usr/lib/zmq/relocatable/libzmqAda.so
-%{_includedir}/zmq/zmq-contexts.adb
-%{_includedir}/zmq/zmq-contexts.ads
-%{_includedir}/zmq/zmq-devices.adb
-%{_includedir}/zmq/zmq-devices.ads
-%{_includedir}/zmq/zmq-low_level.ads
-%{_includedir}/zmq/zmq-messages.adb
-%{_includedir}/zmq/zmq-messages.ads
-%{_includedir}/zmq/zmq-sockets.adb
-%{_includedir}/zmq/zmq-sockets.ads
-%{_includedir}/zmq/zmq-utilities-memory_streams.adb
-%{_includedir}/zmq/zmq-utilities-memory_streams.ads
-%{_includedir}/zmq/zmq-utilities.ads
-%{_includedir}/zmq/zmq.adb
-%{_includedir}/zmq/zmq.ads
-/usr/lib/gnat/zmq.gpr
-/usr/lib/zmq/relocatable/zmq-contexts.ali
-/usr/lib/zmq/relocatable/zmq-devices.ali
-/usr/lib/zmq/relocatable/zmq-low_level.ali
-/usr/lib/zmq/relocatable/zmq-messages.ali
-/usr/lib/zmq/relocatable/zmq-sockets.ali
-/usr/lib/zmq/relocatable/zmq-utilities-memory_streams.ali
-/usr/lib/zmq/relocatable/zmq-utilities.ali
-/usr/lib/zmq/relocatable/zmq.ali
-/usr/lib/zmq/static/zmq-contexts.ali
-/usr/lib/zmq/static/zmq-devices.ali
-/usr/lib/zmq/static/zmq-low_level.ali
-/usr/lib/zmq/static/zmq-messages.ali
-/usr/lib/zmq/static/zmq-sockets.ali
-/usr/lib/zmq/static/zmq-utilities-memory_streams.ali
-/usr/lib/zmq/static/zmq-utilities.ali
-/usr/lib/zmq/static/zmq.ali
-%{_datadir}/zmq/examples/Ada/* 
+%{_prefix}/gnat/lib/zmq/relocatable/libzmqAda.so
+%{_prefix}/gnat/include/zmq/zmq-contexts.adb
+%{_prefix}/gnat/include/zmq/zmq-contexts.ads
+%{_prefix}/gnat/include/zmq/zmq-messages.adb
+%{_prefix}/gnat/include/zmq/zmq-messages.ads
+%{_prefix}/gnat/include/zmq/zmq-sockets.adb
+%{_prefix}/gnat/include/zmq/zmq-sockets.ads
+%{_prefix}/gnat/include/zmq/zmq-utilities-memory_streams.adb
+%{_prefix}/gnat/include/zmq/zmq-utilities-memory_streams.ads
+%{_prefix}/gnat/include/zmq/zmq-utilities.ads
+%{_prefix}/gnat/include/zmq/zmq.adb
+%{_prefix}/gnat/include/zmq/zmq.ads
+%{_prefix}/gnat/include/zmq/zmq-pollsets.adb
+%{_prefix}/gnat/include/zmq/zmq-pollsets.ads
+%{_prefix}/gnat/include/zmq/zmq-proxys.adb
+%{_prefix}/gnat/include/zmq/zmq-proxys.ads
+%{_prefix}/gnat/include/zmq/zmq-sockets-indefinite_typed_generic.adb
+%{_prefix}/gnat/include/zmq/zmq-sockets-indefinite_typed_generic.ads
+%{_prefix}/gnat/include/zmq/zmq-sockets-typed_generic.adb
+%{_prefix}/gnat/include/zmq/zmq-sockets-typed_generic.ads
+%{_prefix}/gnat/include/zmq/zmq-utilities-stream_element_array_image.adb
+%{_prefix}/gnat/include/zmq/zmq-utilities-stream_element_array_image.ads
+%{_prefix}/gnat/include/zmq/zmq-low_level.ads
+
+%{_prefix}/gnat/share/gpr/zmq.gpr
+%{_prefix}/gnat/share/gpr/libzmq.gpr
+%{_prefix}/gnat/lib/zmq/relocatable/zmq-contexts.ali
+%{_prefix}/gnat/lib/zmq/relocatable/zmq-low_level.ali
+%{_prefix}/gnat/lib/zmq/relocatable/zmq-messages.ali
+%{_prefix}/gnat/lib/zmq/relocatable/zmq-sockets.ali
+%{_prefix}/gnat/lib/zmq/relocatable/zmq-utilities-memory_streams.ali
+%{_prefix}/gnat/lib/zmq/relocatable/zmq-utilities.ali
+%{_prefix}/gnat/lib/zmq/relocatable/zmq.ali
+%{_prefix}/gnat/lib/zmq/relocatable/zmq-proxys.ali
+%{_prefix}/gnat/lib/zmq/static/zmq-contexts.ali
+%{_prefix}/gnat/lib/zmq/static/zmq-low_level.ali
+%{_prefix}/gnat/lib/zmq/static/zmq-messages.ali
+%{_prefix}/gnat/lib/zmq/static/zmq-sockets.ali
+%{_prefix}/gnat/lib/zmq/static/zmq-utilities-memory_streams.ali
+%{_prefix}/gnat/lib/zmq/static/zmq-utilities.ali
+%{_prefix}/gnat/lib/zmq/static/zmq.ali
+%{_prefix}/gnat/lib/zmq/static/zmq-pollsets.ali
+%{_prefix}/gnat/lib/zmq/static/zmq-proxys.ali
+%{_prefix}/gnat/lib/zmq/static/zmq-sockets-indefinite_typed_generic.ali
+%{_prefix}/gnat/lib/zmq/static/zmq-sockets-typed_generic.ali
+%{_prefix}/gnat/lib/zmq/static/zmq-utilities-stream_element_array_image.ali
+%{_prefix}/gnat/share/zmq/examples/Ada/* 
 
 %changelog
 * Wed Feb 2 2011 Pavel Zhukov <pavel@zhukoff.net> - 2.0.10-1


### PR DESCRIPTION
The fedora.spec file is not compatible with the current latest version.
Also some changes had to be made, which I have added in the patch file. The patch file used in the spec file, so that it will be applied during rpmbuild.

Please note, that I got and error for the Language "Makfile" and "python", so I have removed them. I have not found the solution to configure suffixes. But at last, with the changes I did, the examples are building without any error.

Maybe if the changes in the patch are satisfying, they can be directly applied in the code, so everybody gets a working environment, where just with 'with "zmq.gpr"' in any project file will work to use all the features provided in this project.