### PR TITLE
Implement task local variable to store global errno

### DIFF
--- a/src/zmq-contexts.adb
+++ b/src/zmq-contexts.adb
@@ -31,6 +31,7 @@
 
 with Interfaces.C;
 with ZMQ.Low_Level;
+with ZMQ.Errors;
 with GNAT.OS_Lib;
 with GNAT.Source_Info;
 package body ZMQ.Contexts is
@@ -51,7 +52,10 @@ package body ZMQ.Contexts is
          raise ZMQ_Error with "Already Initialized";
       end if;
       This.C := Low_Level.zmq_ctx_new;
+
       if This.C = Null_Address then
+         ZMQ.Errors.Set_To_Errno;
+
          raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
            GNAT.Source_Info.Enclosing_Entity;
       end if;
@@ -68,7 +72,10 @@ package body ZMQ.Contexts is
    begin
       if This.Is_Connected then
          Rc := Low_Level.zmq_ctx_destroy (This.C);
+
          if Rc  /= 0 then
+            ZMQ.Errors.Set_To_Errno;
+
             raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
               GNAT.Source_Info.Enclosing_Entity;
          end if;
@@ -76,78 +83,127 @@ package body ZMQ.Contexts is
       end if;
    end Finalize;
 
+   ------------------
+   -- Is_Connected --
+   ------------------
+
    function Is_Connected (This : Context) return Boolean is
    begin
       return This.C /= Null_Address;
    end Is_Connected;
+
+   -------------
+   -- GetImpl --
+   -------------
 
    function GetImpl (This : Context) return System.Address is
    begin
       return This.C;
    end GetImpl;
 
+   ------------------
+   -- Get_Or_Raise --
+   ------------------
+
+   function Get_Or_Raise (This : in out Context; Option : int) return Natural
+   is
+      Result : int;
+   begin
+      Result := Low_Level.zmq_ctx_get
+        (This.C, Option);
+
+      if Result = -1 then
+         ZMQ.Errors.Set_To_Errno;
+
+         raise Program_Error with Error_Message (Integer (Result));
+      end if;
+
+      return Natural (Result);
+   end Get_Or_Raise;
+
+
+   ------------------
+   -- Set_Or_Raise --
+   ------------------
+
+   procedure Set_Or_Raise (This : in out Context; Option : int; Value : int) is
+      Result : int;
+   begin
+      Result := Low_Level.zmq_ctx_set
+        (This.C, Option, Value);
+
+      if Result = -1 then
+         ZMQ.Errors.Set_To_Errno;
+
+         raise Program_Error with Error_Message (Integer (Result));
+      end if;
+   end Set_Or_Raise;
+
+   ------------------------------
+   -- Set_Number_Of_IO_Threads --
+   ------------------------------
 
    not overriding
    procedure Set_Number_Of_IO_Threads
      (This    : in out Context;
       Threads : Natural := 1) is
-      Status : int;
    begin
-      Status :=  Low_Level.zmq_ctx_set
-        (This.C, Low_Level.Defs.ZMQ_IO_THREADS, int (Threads));
-      if Status /= 0 then
-         raise Program_Error with Error_Message (Integer (Status));
-      end if;
+      Set_Or_Raise (This, Low_Level.Defs.ZMQ_IO_THREADS, int (Threads));
    end Set_Number_Of_IO_Threads;
 
+
+   ------------------------------
+   -- Get_Number_Of_IO_Threads --
+   ------------------------------
 
    not overriding
    function Get_Number_Of_IO_Threads (This : in out Context) return Natural is
    begin
-      return Natural
-        (Low_Level.zmq_ctx_get (This.C, Low_Level.Defs.ZMQ_IO_THREADS));
+      return Get_Or_Raise (This, Low_Level.Defs.ZMQ_IO_THREADS);
    end Get_Number_Of_IO_Threads;
+
+   -----------------------------------
+   -- Set_Maximum_Number_Of_Sockets --
+   -----------------------------------
 
    not overriding
    procedure Set_Maximum_Number_Of_Sockets
      (This : in out Context; Count : Positive := 1024) is
-      status : int;
    begin
-      status := Low_Level.zmq_ctx_set
-        (This.C, Low_Level.Defs.ZMQ_MAX_SOCKETS, int (Count));
-      if status /= 0
-      then
-         raise Program_Error with Error_Message (Integer (status));
-      end if;
+      Set_Or_Raise (This, Low_Level.Defs.ZMQ_MAX_SOCKETS, int (Count));
    end Set_Maximum_Number_Of_Sockets;
 
+
+   -----------------------------------
+   -- Get_Maximum_Number_Of_Sockets --
+   -----------------------------------
 
    not overriding
    function Get_Maximum_Number_Of_Sockets
      (This : in out Context) return Natural is
    begin
-      return Natural
-        (Low_Level.zmq_ctx_get (This.C, Low_Level.Defs.ZMQ_MAX_SOCKETS));
+      return Get_Or_Raise (This, Low_Level.Defs.ZMQ_MAX_SOCKETS);
    end Get_Maximum_Number_Of_Sockets;
+
+   --------------
+   -- Set_IPv6 --
+   --------------
 
    not overriding
    procedure Set_IPv6
      (This : in out Context; Enable : Boolean := False) is
-      Status : int;
    begin
-      Status := Low_Level.zmq_ctx_set
-        (This.C, Low_Level.Defs.ZMQ_IPV6, Boolean'Pos (Enable));
-      if Status /= 0
-      then
-         raise Program_Error with Error_Message (Integer (Status));
-      end if;
+      Set_Or_Raise (This, Low_Level.Defs.ZMQ_IPV6, Boolean'Pos (Enable));
    end Set_IPv6;
+
+   --------------
+   -- Get_IPv6 --
+   --------------
 
    not overriding
    function Get_IPv6 (This : in out Context) return Boolean is
    begin
-      return Low_Level.zmq_ctx_get
-        (This.C, Low_Level.Defs.ZMQ_MAX_SOCKETS) = 1;
+      return Get_Or_Raise (This, Low_Level.Defs.ZMQ_MAX_SOCKETS) = 1;
    end Get_IPv6;
 
 

--- a/src/zmq-errors.adb
+++ b/src/zmq-errors.adb
@@ -47,6 +47,16 @@ package body ZMQ.Errors is
       return Local_Error_Attr.Value;
    end Get_Last_Error;
 
+   ------------------------
+   -- Last_Error_Message --
+   ------------------------
+
+   function Last_Error_Message
+     (Default : String  := "") return String is
+   begin
+      return GNAT.OS_Lib.Errno_Message (Get_Last_Error, Default);
+   end Last_Error_Message;
+
    --------------------
    -- Set_Last_Error --
    --------------------

--- a/src/zmq-errors.adb
+++ b/src/zmq-errors.adb
@@ -2,9 +2,9 @@
 --                                                                           --
 --                             0MQ Ada-binding                               --
 --                                                                           --
---                           Z M Q . P R O X Y S                             --
+--                                   Z M Q                                   --
 --                                                                           --
---                                  B o d y                                  --
+--                                  S p e c                                  --
 --                                                                           --
 --            Copyright (C) 2020-2030, per.s.sandberg@bahnhof.se             --
 --                                                                           --
@@ -29,30 +29,40 @@
 --  OTHER DEALINGS IN THE SOFTWARE.                                          --
 -------------------------------------------------------------------------------
 
-with ZMQ.Low_Level;
-with Interfaces.C; use Interfaces.C;
-with System; use System;
+with Ada.Task_Attributes;
+with GNAT.OS_Lib;
 
-with ZMQ.Errors;
+package body ZMQ.Errors is
 
-package body ZMQ.Proxys is
---
------------
--- Proxy --
------------
+   package Local_Error_Attr is new Ada.Task_Attributes
+     (Attribute     => Integer,
+      Initial_Value => 0);
 
-   procedure Proxy
-     (Frontend  : not null access Sockets.Socket;
-      Backend   : not null access Sockets.Socket;
-      Capture   : access Sockets.Socket := null)
-   is
-      Dummy : int;
-      pragma Unreferenced (Dummy);
+   --------------------
+   -- Get_Last_Error --
+   --------------------
+
+   function Get_Last_Error return Integer is
    begin
-      Dummy := ZMQ.Low_Level.zmq_proxy
-        (Frontend.Get_Impl, Backend.Get_Impl,
-         (if Capture /= null then Capture.Get_Impl else System.Null_Address));
-      ZMQ.Errors.Set_To_Errno;
-   end Proxy;
+      return Local_Error_Attr.Value;
+   end Get_Last_Error;
 
-end ZMQ.Proxys;
+   --------------------
+   -- Set_Last_Error --
+   --------------------
+
+   procedure Set_Last_Error (Error : Integer) is
+   begin
+      Local_Error_Attr.Set_Value (Error);
+   end Set_Last_Error;
+
+   ------------------
+   -- Set_To_Errno --
+   ------------------
+
+   procedure Set_To_Errno is
+   begin
+      Local_Error_Attr.Set_Value (GNAT.OS_Lib.Errno);
+   end Set_To_Errno;
+
+end ZMQ.Errors;

--- a/src/zmq-errors.ads
+++ b/src/zmq-errors.ads
@@ -35,6 +35,12 @@ package ZMQ.Errors is
    --  Returns the last set error value.
    --  This is a task local variable.
 
+   function Last_Error_Message
+     (Default : String  := "") return String;
+   --  Return a message describing the last error. If none is provided
+   --  by the system, return Default if not empty, else return a generic
+   --  message indicating the numeric errno value.
+
    procedure Set_Last_Error (Error : Integer);
    --  Stores Error as last error in a task local variable.
 

--- a/src/zmq-errors.ads
+++ b/src/zmq-errors.ads
@@ -2,9 +2,9 @@
 --                                                                           --
 --                             0MQ Ada-binding                               --
 --                                                                           --
---                           Z M Q . P R O X Y S                             --
+--                                   Z M Q                                   --
 --                                                                           --
---                                  B o d y                                  --
+--                                  S p e c                                  --
 --                                                                           --
 --            Copyright (C) 2020-2030, per.s.sandberg@bahnhof.se             --
 --                                                                           --
@@ -29,30 +29,19 @@
 --  OTHER DEALINGS IN THE SOFTWARE.                                          --
 -------------------------------------------------------------------------------
 
-with ZMQ.Low_Level;
-with Interfaces.C; use Interfaces.C;
-with System; use System;
+package ZMQ.Errors is
 
-with ZMQ.Errors;
+   function Get_Last_Error return Integer;
+   --  Returns the last set error value.
+   --  This is a task local variable.
 
-package body ZMQ.Proxys is
---
------------
--- Proxy --
------------
+   procedure Set_Last_Error (Error : Integer);
+   --  Stores Error as last error in a task local variable.
 
-   procedure Proxy
-     (Frontend  : not null access Sockets.Socket;
-      Backend   : not null access Sockets.Socket;
-      Capture   : access Sockets.Socket := null)
-   is
-      Dummy : int;
-      pragma Unreferenced (Dummy);
-   begin
-      Dummy := ZMQ.Low_Level.zmq_proxy
-        (Frontend.Get_Impl, Backend.Get_Impl,
-         (if Capture /= null then Capture.Get_Impl else System.Null_Address));
-      ZMQ.Errors.Set_To_Errno;
-   end Proxy;
+   procedure Set_To_Errno;
+   --  Stores the current C errno global variable as last error in a task local
+   --  variable.
 
-end ZMQ.Proxys;
+   pragma Inline (Get_Last_Error, Set_Last_Error, Set_To_Errno);
+
+end ZMQ.Errors;

--- a/src/zmq-messages.adb
+++ b/src/zmq-messages.adb
@@ -35,6 +35,9 @@ with GNAT.OS_Lib;
 with GNAT.Source_Info;
 with Ada.Unchecked_Conversion;
 with System.Address_To_Access_Conversions;
+
+with ZMQ.Errors;
+
 package body ZMQ.Messages is
    use Interfaces.C;
 
@@ -51,7 +54,10 @@ package body ZMQ.Messages is
       else
          Ret := Low_Level.zmq_msg_init (Self.Msg'Access);
       end if;
+
       if Ret /= 0 then
+         ZMQ.Errors.Set_To_Errno;
+
          raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
            GNAT.Source_Info.Enclosing_Entity;
       end if;
@@ -102,6 +108,8 @@ package body ZMQ.Messages is
                                           Free,
                                           Hint);
       if Ret /= 0 then
+         ZMQ.Errors.Set_To_Errno;
+
          raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
            GNAT.Source_Info.Enclosing_Entity;
       end if;
@@ -275,7 +283,10 @@ package body ZMQ.Messages is
       if Self.Is_Valid then
          Ret := Low_Level.zmq_msg_close (Self.Msg'Access);
          Self.Is_Valid := False;
+
          if Ret /= 0 then
+            ZMQ.Errors.Set_To_Errno;
+
             raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
               GNAT.Source_Info.Enclosing_Entity;
          end if;

--- a/src/zmq-messages.adb
+++ b/src/zmq-messages.adb
@@ -55,6 +55,8 @@ package body ZMQ.Messages is
          raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
            GNAT.Source_Info.Enclosing_Entity;
       end if;
+
+      Self.Is_Valid := True;
    end Initialize;
 
    --  ========================================================================
@@ -103,6 +105,8 @@ package body ZMQ.Messages is
          raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
            GNAT.Source_Info.Enclosing_Entity;
       end if;
+
+      Self.Is_Valid := True;
    end Initialize;
 
 
@@ -268,10 +272,13 @@ package body ZMQ.Messages is
    procedure Finalize (Self : in out Message) is
       Ret : int;
    begin
-      Ret := Low_Level.zmq_msg_close (Self.Msg'Access);
-      if Ret /= 0 then
-         raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
-           GNAT.Source_Info.Enclosing_Entity;
+      if Self.Is_Valid then
+         Ret := Low_Level.zmq_msg_close (Self.Msg'Access);
+         Self.Is_Valid := False;
+         if Ret /= 0 then
+            raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
+              GNAT.Source_Info.Enclosing_Entity;
+         end if;
       end if;
    end Finalize;
 

--- a/src/zmq-messages.ads
+++ b/src/zmq-messages.ads
@@ -145,6 +145,7 @@ package ZMQ.Messages is
 private
    type Message is new Ada.Finalization.Limited_Controlled with record
       Msg            : aliased ZMQ.Low_Level.zmq_msg_t;
+      Is_Valid       : Boolean := False;
    end record;
 
 end ZMQ.Messages;

--- a/src/zmq-pollsets.adb
+++ b/src/zmq-pollsets.adb
@@ -31,6 +31,8 @@
 
 with GNAT.OS_Lib;
 
+with ZMQ.Errors;
+
 package body ZMQ.Pollsets is
    use Interfaces.C;
    --  use type ZMQ.Sockets.Any_Socket;
@@ -148,6 +150,8 @@ package body ZMQ.Pollsets is
       --  Values greater or equal to zero indicate number of poll items with
       --  signaled events. Other values indicate an error condition.
       if Ret < 0 then
+         ZMQ.Errors.Set_To_Errno;
+
          raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno);
       end if;
 

--- a/src/zmq-sockets.adb
+++ b/src/zmq-sockets.adb
@@ -29,6 +29,7 @@
 --  OTHER DEALINGS IN THE SOFTWARE.                                          --
 -------------------------------------------------------------------------------
 
+with ZMQ.Errors;
 with ZMQ.Low_Level;
 with Interfaces.C.Strings;
 with GNAT.OS_Lib;
@@ -100,6 +101,7 @@ package body ZMQ.Sockets is
    ----------------
    -- Initialize --
    ----------------
+
    not overriding procedure Initialize
      (This         : in out Socket;
       With_Context : Contexts.Context;
@@ -116,6 +118,8 @@ package body ZMQ.Sockets is
       This.C := Low_Level.zmq_socket (With_Context.GetImpl,
                                       Socket_Type'Pos (Kind));
       if This.C = Null_Address then
+         ZMQ.Errors.Set_To_Errno;
+
          raise ZMQ_Error with "Unable to initialize";
       end if;
    end Initialize;
@@ -132,11 +136,17 @@ package body ZMQ.Sockets is
       Ret  : int;
    begin
       Ret := Low_Level.zmq_bind (This.C, Addr);
-      Free (Addr);
+
       if Ret /= 0 then
+         ZMQ.Errors.Set_To_Errno;
+
+         Free (Addr);
+
          raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
            GNAT.Source_Info.Enclosing_Entity & "(" & Address & ")";
       end if;
+
+      Free (Addr);
    end Bind;
 
    procedure Bind (This    : in out Socket;
@@ -144,6 +154,10 @@ package body ZMQ.Sockets is
    begin
       This.Bind (To_String (Address));
    end Bind;
+
+   ------------
+   -- Unbind --
+   ------------
 
    not overriding procedure Unbind
      (This    : in out Socket;
@@ -153,11 +167,17 @@ package body ZMQ.Sockets is
       Ret  : int;
    begin
       Ret := Low_Level.zmq_unbind (This.C, Addr);
-      Free (Addr);
+
       if Ret /= 0 then
+         ZMQ.Errors.Set_To_Errno;
+
+         Free (Addr);
+
          raise ZMQ_Error with  Error_Message (GNAT.OS_Lib.Errno) & " in " &
            GNAT.Source_Info.Enclosing_Entity & "(" & Address & ")";
       end if;
+
+      Free (Addr);
    end Unbind;
 
    procedure Unbind (This    : in out Socket;
@@ -165,6 +185,10 @@ package body ZMQ.Sockets is
    begin
       This.Unbind (To_String (Address));
    end Unbind;
+
+   ----------------
+   -- Setsockopt --
+   ----------------
 
    procedure Setsockopt (This       : in out Socket;
                          Option     : Interfaces.C.int;
@@ -174,15 +198,14 @@ package body ZMQ.Sockets is
    begin
       Ret :=
         Low_Level.zmq_setsockopt (This.C, Option, Value, size_t (Value_Size));
+
       if Ret /= 0 then
+         ZMQ.Errors.Set_To_Errno;
+
          raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
            GNAT.Source_Info.Enclosing_Entity & "(" & Option'Img & ")";
       end if;
    end Setsockopt;
-
-   ----------------
-   -- setsockopt --
-   ----------------
 
    not overriding procedure Setsockopt
      (This   : in out Socket;
@@ -193,10 +216,6 @@ package body ZMQ.Sockets is
       This.Setsockopt (Option, Value'Address, Value'Length);
    end Setsockopt;
 
-   ----------------
-   -- setsockopt --
-   ----------------
-
    not overriding procedure Setsockopt
      (This   : in out Socket;
       Option : Interfaces.C.int;
@@ -205,10 +224,6 @@ package body ZMQ.Sockets is
    begin
       This.Setsockopt (Option, Value'Address, 1);
    end Setsockopt;
-
-   ----------------
-   -- setsockopt --
-   ----------------
 
    not overriding procedure Setsockopt
      (This   : in out Socket;
@@ -228,9 +243,6 @@ package body ZMQ.Sockets is
       This.Setsockopt (Option, Value'Address, 8);
    end Setsockopt;
 
-   ----------------
-   -- setsockopt --
-   ----------------
    not overriding procedure Setsockopt
      (This   : in out Socket;
       Option : Interfaces.C.int;
@@ -270,11 +282,17 @@ package body ZMQ.Sockets is
       Ret  : int;
    begin
       Ret := Low_Level.zmq_connect (This.C, Addr);
-      Free (Addr);
+
       if Ret /= 0 then
+         ZMQ.Errors.Set_To_Errno;
+
+         Free (Addr);
+
          raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
            GNAT.Source_Info.Enclosing_Entity & "(" & Address & ")";
       end if;
+
+      Free (Addr);
    end Connect;
 
    procedure Connect
@@ -297,7 +315,10 @@ package body ZMQ.Sockets is
       Ret : int;
    begin
       Ret := Low_Level.zmq_msg_send (Msg.GetImpl, This.C, int (Flags));
+
       if Ret = -1 then
+         ZMQ.Errors.Set_To_Errno;
+
          raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
            GNAT.Source_Info.Enclosing_Entity;
       end if;
@@ -355,30 +376,17 @@ package body ZMQ.Sockets is
       Ret :=
         Low_Level.zmq_send
           (This.C, Msg_Address, Interfaces.C.size_t (Msg_Length), int (Flags));
+
       if Ret = -1 then
+         ZMQ.Errors.Set_To_Errno;
+
          raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
            GNAT.Source_Info.Enclosing_Entity;
       end if;
    end Send;
 
-   --     -----------
-   --     -- flush --
-   --     -----------
-   --
-   --     not overriding procedure flush
-   --       (This    : in out Socket)
-   --     is
-   --        ret  : int;
-   --     begin
-   --        ret := Low_Level.zmq_flush (This.c);
-   --        if ret /= 0 then
-   --           raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in "
-   --             & GNAT.Source_Info.Enclosing_Entity;
-   --        end if;
-   --     end flush;
-
    ----------
-   -- recv --
+   -- Recv --
    ----------
 
    not overriding procedure Recv
@@ -391,6 +399,8 @@ package body ZMQ.Sockets is
       Ret := Low_Level.zmq_msg_recv (Msg.GetImpl, This.C, int (Flags));
 
       if Ret = -1 then
+         ZMQ.Errors.Set_To_Errno;
+
          raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
            GNAT.Source_Info.Enclosing_Entity;
       end if;
@@ -405,7 +415,6 @@ package body ZMQ.Sockets is
    end Recv;
 
    not overriding
-
    function Recv (This  : in Socket;
                   Flags : Socket_Flags := No_Flags) return String is
       Msg : Messages.Message;
@@ -462,12 +471,19 @@ package body ZMQ.Sockets is
    begin
       if This.C /= Null_Address then
          Ret := Low_Level.zmq_close (This.C);
+
          if Ret /= 0 then
+            ZMQ.Errors.Set_To_Errno;
+
             raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno);
          end if;
          This.C := Null_Address;
       end if;
    end Finalize;
+
+   -----------
+   -- Proxy --
+   -----------
 
    procedure Proxy (Frontend : not null access Socket;
                     Backend  : not null access Socket'Class;
@@ -478,10 +494,17 @@ package body ZMQ.Sockets is
         (Frontend.C,
          Backend.C,
          (if Capture /= null then Capture.C else System.Null_Address));
+
       if Ret /= 0 then
+         ZMQ.Errors.Set_To_Errno;
+
          raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno);
       end if;
    end Proxy;
+
+   -----------------------------------------------
+   -- Set_High_Water_Mark_For_Outbound_Messages --
+   -----------------------------------------------
 
    not overriding
    procedure Set_High_Water_Mark_For_Outbound_Messages
@@ -492,6 +515,10 @@ package body ZMQ.Sockets is
       This.Setsockopt (ZMQ.Low_Level.Defs.ZMQ_SNDHWM, Messages);
    end Set_High_Water_Mark_For_Outbound_Messages;
 
+   ----------------------------------------------
+   -- Set_High_Water_Mark_For_Inbound_Messages --
+   ----------------------------------------------
+
    not overriding
    procedure Set_High_Water_Mark_For_Inbound_Messages
      (This     : in out Socket;
@@ -501,6 +528,10 @@ package body ZMQ.Sockets is
       This.Setsockopt (ZMQ.Low_Level.Defs.ZMQ_RCVHWM, Messages);
    end Set_High_Water_Mark_For_Inbound_Messages;
 
+   ---------------------------
+   -- Set_Disk_Offload_Size --
+   ---------------------------
+
    not overriding
    procedure Set_Disk_Offload_Size (This  : in out Socket;
                                     Value : Natural) is
@@ -508,12 +539,20 @@ package body ZMQ.Sockets is
       null; -- This.setsockopt (ZMQ.Low_Level.Defs.SWAP, Value);
    end Set_Disk_Offload_Size;
 
+   ----------------------------
+   -- Set_IO_Thread_Affinity --
+   ----------------------------
+
    not overriding
    procedure Set_IO_Thread_Affinity (This    : in out Socket;
                                      Threads : Thread_Bitmap) is
    begin
       This.Setsockopt (ZMQ.Low_Level.Defs.ZMQ_AFFINITY, Threads'Address, 4);
    end Set_IO_Thread_Affinity;
+
+   -------------------------
+   -- Set_Socket_Identity --
+   -------------------------
 
    not overriding
    procedure Set_Socket_Identity
@@ -530,12 +569,20 @@ package body ZMQ.Sockets is
       This.Setsockopt (ZMQ.Low_Level.Defs.ZMQ_IDENTITY, Value);
    end Set_Socket_Identity;
 
+   ------------------------------
+   -- Establish_Message_Filter --
+   ------------------------------
+
    not overriding
    procedure Establish_Message_Filter (This  : in out Socket;
                                        Value : String) is
    begin
       This.Setsockopt (ZMQ.Low_Level.Defs.ZMQ_SUBSCRIBE, Value);
    end Establish_Message_Filter;
+
+   ------------------------------
+   -- Establish_Message_Filter --
+   ------------------------------
 
    not overriding
    procedure Establish_Message_Filter
@@ -551,6 +598,10 @@ package body ZMQ.Sockets is
    begin
       This.Setsockopt (ZMQ.Low_Level.Defs.ZMQ_SUBSCRIBE, To_String (Value));
    end Establish_Message_Filter;
+
+   ---------------------------
+   -- Remove_Message_Filter --
+   ---------------------------
 
    not overriding
    procedure Remove_Message_Filter (This  : in out Socket;
@@ -573,6 +624,10 @@ package body ZMQ.Sockets is
       This.Setsockopt (ZMQ.Low_Level.Defs.ZMQ_UNSUBSCRIBE, Value);
    end Remove_Message_Filter;
 
+   -----------------------------
+   -- Set_Multicast_Data_Rate --
+   -----------------------------
+
    not overriding
    procedure Set_Multicast_Data_Rate
      (This                : in out Socket;
@@ -580,6 +635,10 @@ package body ZMQ.Sockets is
    begin
       This.Setsockopt (ZMQ.Low_Level.Defs.ZMQ_RATE, Kilobits_Per_Second);
    end Set_Multicast_Data_Rate;
+
+   -------------------------------------
+   -- Set_Multicast_Recovery_Interval --
+   -------------------------------------
 
    not overriding
    procedure Set_Multicast_Recovery_Interval (This : in out Socket;
@@ -590,11 +649,19 @@ package body ZMQ.Sockets is
    end Set_Multicast_Recovery_Interval;
    not overriding
 
+     ----------------------------
+     -- Set_Multicast_Loopback --
+     ----------------------------
+
    procedure Set_Multicast_Loopback (This   : in out Socket;
                                      Enable : Boolean) is
    begin
       null; -- This.setsockopt (ZMQ.Low_Level.Defs.ZMQ_HWM, Enable);
    end Set_Multicast_Loopback;
+
+   -------------------------------------
+   -- Set_Kernel_Transmit_Buffer_Size --
+   -------------------------------------
 
    not overriding
    procedure Set_Kernel_Transmit_Buffer_Size (This  : in out Socket;
@@ -603,6 +670,10 @@ package body ZMQ.Sockets is
       This.Setsockopt (ZMQ.Low_Level.Defs.ZMQ_SNDBUF, Bytes);
    end Set_Kernel_Transmit_Buffer_Size;
 
+   ------------------------------------
+   -- Set_Kernel_Receive_Buffer_Size --
+   ------------------------------------
+
    not overriding
    procedure Set_Kernel_Receive_Buffer_Size (This  : in out Socket;
                                              Bytes : Natural) is
@@ -610,12 +681,20 @@ package body ZMQ.Sockets is
       This.Setsockopt (ZMQ.Low_Level.Defs.ZMQ_RCVBUF, Bytes);
    end Set_Kernel_Receive_Buffer_Size;
 
+   -------------------------------------------
+   -- Get_Linger_Period_For_Socket_Shutdown --
+   -------------------------------------------
+
    not overriding
    function Get_Linger_Period_For_Socket_Shutdown
      (This : Socket) return Duration is
    begin
       return This.Getsockopt (ZMQ.Low_Level.Defs.ZMQ_LINGER);
    end Get_Linger_Period_For_Socket_Shutdown;
+
+   -------------------------------------------
+   -- Set_Linger_Period_For_Socket_Shutdown --
+   -------------------------------------------
 
    not overriding
    procedure Set_Linger_Period_For_Socket_Shutdown
@@ -625,12 +704,20 @@ package body ZMQ.Sockets is
       This.Setsockopt (ZMQ.Low_Level.Defs.ZMQ_LINGER, Period);
    end Set_Linger_Period_For_Socket_Shutdown;
 
+   -------------------------------
+   -- Get_Reconnection_Interval --
+   -------------------------------
+
    not overriding
    function Get_Reconnection_Interval
      (This : Socket) return Duration is
    begin
       return This.Getsockopt (ZMQ.Low_Level.Defs.ZMQ_RECONNECT_IVL);
    end Get_Reconnection_Interval;
+
+   -------------------------------
+   -- Set_Reconnection_Interval --
+   -------------------------------
 
    not overriding
    procedure Set_Reconnection_Interval
@@ -642,6 +729,10 @@ package body ZMQ.Sockets is
          Integer (Duration_To_Msecs (Period)));
    end Set_Reconnection_Interval;
 
+   ---------------------------------------
+   -- Get_Maximum_Reconnection_Interval --
+   ---------------------------------------
+
    not overriding
    function Get_Maximum_Reconnection_Interval
      (This : Socket) return Duration
@@ -649,6 +740,10 @@ package body ZMQ.Sockets is
    begin
       return This.Getsockopt (ZMQ.Low_Level.Defs.ZMQ_RECONNECT_IVL_MAX);
    end Get_Maximum_Reconnection_Interval;
+
+   ---------------------------------------
+   -- Set_Maximum_Reconnection_Interval --
+   ---------------------------------------
 
    not overriding
    procedure Set_Maximum_Reconnection_Interval
@@ -660,12 +755,20 @@ package body ZMQ.Sockets is
          Integer (Duration_To_Msecs (Period)));
    end Set_Maximum_Reconnection_Interval;
 
+   ----------------------------------------------------------------
+   -- Get_Maximum_Length_Of_The_Queue_Of_Outstanding_Connections --
+   ----------------------------------------------------------------
+
    not overriding
    function Get_Maximum_Length_Of_The_Queue_Of_Outstanding_Connections
      (This : Socket) return Natural is
    begin
       return This.Getsockopt (Low_Level.Defs.ZMQ_BACKLOG);
    end Get_Maximum_Length_Of_The_Queue_Of_Outstanding_Connections;
+
+   ----------------------------------------------------------------
+   -- Set_Maximum_Length_Of_The_Queue_Of_Outstanding_Connections --
+   ----------------------------------------------------------------
 
    not overriding
    procedure Set_Maximum_Length_Of_The_Queue_Of_Outstanding_Connections
@@ -675,12 +778,20 @@ package body ZMQ.Sockets is
       This.Setsockopt (Low_Level.Defs.ZMQ_BACKLOG, Connections);
    end Set_Maximum_Length_Of_The_Queue_Of_Outstanding_Connections;
 
+   -------------------------------------------------
+   -- Get_Maximum_Acceptable_Inbound_Message_Size --
+   -------------------------------------------------
+
    not overriding
    function Get_Maximum_Acceptable_Inbound_Message_Size
      (This : Socket) return Long_Long_Integer is
    begin
       return This.Getsockopt (Low_Level.Defs.ZMQ_MAXMSGSIZE);
    end Get_Maximum_Acceptable_Inbound_Message_Size;
+
+   -------------------------------------------------
+   -- Set_Maximum_Acceptable_Inbound_Message_Size --
+   -------------------------------------------------
 
    not overriding
    procedure Set_Maximum_Acceptable_Inbound_Message_Size
@@ -690,12 +801,20 @@ package body ZMQ.Sockets is
       This.Setsockopt (Low_Level.Defs.ZMQ_MAXMSGSIZE, Bytes);
    end Set_Maximum_Acceptable_Inbound_Message_Size;
 
+   ----------------------------------------------------
+   -- Get_Maximum_Network_Hops_For_Multicast_Packets --
+   ----------------------------------------------------
+
    not overriding
    function Get_Maximum_Network_Hops_For_Multicast_Packets
      (This : Socket) return Positive is
    begin
       return This.Getsockopt (Low_Level.Defs.ZMQ_MULTICAST_HOPS);
    end Get_Maximum_Network_Hops_For_Multicast_Packets;
+
+   ----------------------------------------------------
+   -- Set_Maximum_Network_Hops_For_Multicast_Packets --
+   ----------------------------------------------------
 
    not overriding
    procedure Set_Maximum_Network_Hops_For_Multicast_Packets
@@ -705,12 +824,20 @@ package body ZMQ.Sockets is
       This.Setsockopt (Low_Level.Defs.ZMQ_MULTICAST_HOPS, Network_Hops);
    end Set_Maximum_Network_Hops_For_Multicast_Packets;
 
+   -------------------------
+   -- Get_Recieve_Timeout --
+   -------------------------
+
    not overriding
    function Get_Recieve_Timeout
      (This : Socket) return Duration is
    begin
       return This.Getsockopt (Low_Level.Defs.ZMQ_RCVTIMEO);
    end Get_Recieve_Timeout;
+
+   -------------------------
+   -- Set_Recieve_Timeout --
+   -------------------------
 
    not overriding
    procedure Set_Recieve_Timeout
@@ -721,12 +848,20 @@ package body ZMQ.Sockets is
         (Low_Level.Defs.ZMQ_RCVTIMEO, Integer (Duration_To_Msecs (Timeout)));
    end Set_Recieve_Timeout;
 
+   ----------------------
+   -- Get_Send_Timeout --
+   ----------------------
+
    not overriding
    function Get_Send_Timeout
      (This : Socket) return Duration is
    begin
       return This.Getsockopt (Low_Level.Defs.ZMQ_SNDTIMEO);
    end Get_Send_Timeout;
+
+   ----------------------
+   -- Set_Send_Timeout --
+   ----------------------
 
    not overriding
    procedure Set_Send_Timeout
@@ -737,12 +872,20 @@ package body ZMQ.Sockets is
         (Low_Level.Defs.ZMQ_SNDTIMEO, Integer (Duration_To_Msecs (Timeout)));
    end Set_Send_Timeout;
 
+   -----------------------
+   -- Get_Use_IPv4_Only --
+   -----------------------
+
    not overriding
    function Get_Use_IPv4_Only
      (This : Socket) return Boolean is
    begin
       return This.Getsockopt (Low_Level.Defs.ZMQ_IPV4ONLY);
    end Get_Use_IPv4_Only;
+
+   -----------------------
+   -- Set_Use_IPv4_Only --
+   -----------------------
 
    not overriding
    procedure Set_Use_IPv4_Only
@@ -755,12 +898,20 @@ package body ZMQ.Sockets is
    --  ========================================================================
    --  ========================================================================
 
+   --------------
+   -- Get_Impl --
+   --------------
+
    function Get_Impl (This : in Socket) return System.Address is
    begin
       return This.C;
    end Get_Impl;
 
    -------------
+
+   ----------------
+   -- Getsockopt --
+   ----------------
 
    not overriding
    procedure Getsockopt (This       : in Socket;
@@ -773,7 +924,10 @@ package body ZMQ.Sockets is
       Ret :=
         Low_Level.zmq_getsockopt (This.C, Option, Value, Value_Size_I'Access);
       Value_Size := Natural (Value_Size_I);
+
       if Ret /= 0 then
+         ZMQ.Errors.Set_To_Errno;
+
          raise ZMQ_Error with Error_Message (GNAT.OS_Lib.Errno) & " in " &
            GNAT.Source_Info.Enclosing_Entity & "(" & Option'Img & ")";
       end if;
@@ -837,10 +991,18 @@ package body ZMQ.Sockets is
       return Msecs_To_Duration (Get_C_Int (This, Option));
    end Getsockopt;
 
+   ----------------------------------
+   -- More_Message_Parts_To_Follow --
+   ----------------------------------
+
    function More_Message_Parts_To_Follow (This : Socket) return Boolean is
    begin
       return This.Getsockopt (ZMQ.Low_Level.Defs.ZMQ_RCVMORE);
    end More_Message_Parts_To_Follow;
+
+   -----------------------------------------------
+   -- Get_High_Water_Mark_For_Outbound_Messages --
+   -----------------------------------------------
 
    function Get_High_Water_Mark_For_Outbound_Messages
      (This : Socket) return Natural is
@@ -848,11 +1010,19 @@ package body ZMQ.Sockets is
       return This.Getsockopt (ZMQ.Low_Level.Defs.ZMQ_SNDHWM);
    end Get_High_Water_Mark_For_Outbound_Messages;
 
+   ----------------------------------------------
+   -- Get_High_Water_Mark_For_Inbound_Messages --
+   ----------------------------------------------
+
    function Get_High_Water_Mark_For_Inbound_Messages
      (This : Socket) return Natural is
    begin
       return This.Getsockopt (ZMQ.Low_Level.Defs.ZMQ_RCVHWM);
    end Get_High_Water_Mark_For_Inbound_Messages;
+
+   ----------------------------
+   -- Get_IO_Thread_Affinity --
+   ----------------------------
 
    function Get_IO_Thread_Affinity (This : Socket) return Thread_Bitmap is
       Value_Size : Natural := Thread_Bitmap'Size / System.Storage_Unit;
@@ -866,21 +1036,37 @@ package body ZMQ.Sockets is
       end return;
    end Get_IO_Thread_Affinity;
 
+   -------------------------
+   -- Get_Socket_Identity --
+   -------------------------
+
    function Get_Socket_Identity
      (This : Socket) return Ada.Streams.Stream_Element_Array is
    begin
       return This.Getsockopt (ZMQ.Low_Level.Defs.ZMQ_IDENTITY);
    end Get_Socket_Identity;
 
+   -----------------------------
+   -- Get_Multicast_Data_Rate --
+   -----------------------------
+
    function Get_Multicast_Data_Rate (This : Socket) return Natural is
    begin
       return This.Getsockopt (ZMQ.Low_Level.Defs.ZMQ_RATE);
    end Get_Multicast_Data_Rate;
 
+   -------------------------------------
+   -- Get_Multicast_Recovery_Interval --
+   -------------------------------------
+
    function Get_Multicast_Recovery_Interval (This : Socket) return Duration is
    begin
       return This.Getsockopt (ZMQ.Low_Level.Defs.ZMQ_RECOVERY_IVL);
    end Get_Multicast_Recovery_Interval;
+
+   ----------------------------
+   -- Get_Multicast_Loopback --
+   ----------------------------
 
    function Get_Multicast_Loopback (This : Socket) return Boolean is
       pragma Unreferenced (This);
@@ -888,10 +1074,18 @@ package body ZMQ.Sockets is
       return False; -- This.getsockopt (ZMQ.Low_Level.Defs.ZMQ_MCAST_LOOP);
    end Get_Multicast_Loopback;
 
+   -------------------------------------
+   -- Get_Kernel_Transmit_Buffer_Size --
+   -------------------------------------
+
    function Get_Kernel_Transmit_Buffer_Size (This : Socket) return Integer is
    begin
       return Getsockopt (This, ZMQ.Low_Level.Defs.ZMQ_SNDBUF);
    end Get_Kernel_Transmit_Buffer_Size;
+
+   ------------------------------------
+   -- Get_Kernel_Receive_Buffer_Size --
+   ------------------------------------
 
    function Get_Kernel_Receive_Buffer_Size (This : Socket) return Integer is
    begin
@@ -899,10 +1093,18 @@ package body ZMQ.Sockets is
    end Get_Kernel_Receive_Buffer_Size;
 
    not overriding
+     --------------------------
+     -- Retrieve_Socket_Type --
+     --------------------------
+
    function Retrieve_Socket_Type (This : in Socket) return Socket_Type is
    begin
       return Socket_Type'Val (Get_C_Int (This, Low_Level.Defs.ZMQ_TYPE));
    end Retrieve_Socket_Type;
+
+   ----------
+   -- Read --
+   ----------
 
    procedure Read
      (Stream : in out Socket_Stream;
@@ -912,12 +1114,20 @@ package body ZMQ.Sockets is
       raise Program_Error with "unimplemented function Read";
    end Read;
 
+   -----------
+   -- Write --
+   -----------
+
    procedure Write
      (Stream : in out Socket_Stream;
       Item   : Ada.Streams.Stream_Element_Array) is
    begin
       raise Program_Error with "unimplemented function Write";
    end Write;
+
+   -----------------
+   -- Read_Socket --
+   -----------------
 
    procedure Read_Socket
      (Stream : not null access Ada.Streams.Root_Stream_Type'Class;
@@ -926,6 +1136,10 @@ package body ZMQ.Sockets is
       raise Program_Error with "Sockets are not streameble";
    end Read_Socket;
 
+   ------------------
+   -- Write_Socket --
+   ------------------
+
    procedure Write_Socket
      (Stream : not null access Ada.Streams.Root_Stream_Type'Class;
       S      : Socket)
@@ -933,6 +1147,10 @@ package body ZMQ.Sockets is
    begin
       raise Program_Error with "Sockets are not streameble";
    end Write_Socket;
+
+   ------------
+   -- Stream --
+   ------------
 
    function Stream
      (This : Socket) return not null access Ada.Streams.Root_Stream_Type'Class

--- a/src/zmq-sockets.ads
+++ b/src/zmq-sockets.ads
@@ -98,6 +98,7 @@ package ZMQ.Sockets is
    not overriding function Retrieve_Socket_Type
      (This : in Socket)
       return Socket_Type;
+
    --  ========================================================================
    --  Socket control
    --  ========================================================================

--- a/src/zmq.adb
+++ b/src/zmq.adb
@@ -30,6 +30,7 @@
 -------------------------------------------------------------------------------
 
 
+
 with Interfaces.C;
 with Interfaces.C.Strings;
 with ZMQ.Low_Level;

--- a/src/zmq.ads
+++ b/src/zmq.ads
@@ -30,7 +30,6 @@
 -------------------------------------------------------------------------------
 
 
-
 --  This is the Ada binding to 0MQ  The Intelligent Transport Layer
 --  http://www.zeromq.org/
 


### PR DESCRIPTION
This prevents clobbering of errno when Ada raises or catches an exception. Since the binding raises a single exception for everything, it's impossible to rely on the value of errno after an exception is raised making it difficult to determine whether the exception can be recovered from.

Also fixed an incorrect  constant use when getting the socket option for IPv6.

Closes issue #26 

https://github.com/persan/zeromq-Ada/issues/26